### PR TITLE
Various bug fixes.

### DIFF
--- a/src/Plugin/WebformHandler/CookieWebformHandler.php
+++ b/src/Plugin/WebformHandler/CookieWebformHandler.php
@@ -42,24 +42,11 @@ class CookieWebformHandler extends WebformHandlerBase
 
     public function buildConfigurationForm(array $form, FormStateInterface $form_state)
     {
-        $config = $this->getConfiguration();
-        $settings = $config['settings'];
-        $timezone = \Drupal::config('system.date')->get('timezone')['default'];
-
-        if (empty($settings['expires'])) {
-            $expires = \Drupal::time()->getRequestTime() + 60 * 60 * 24;
-            $exp = new DrupalDateTime('now', $timezone);
-            $exp->setTimestamp($expires);
-            $expires = $exp;
-        } elseif (is_numeric($settings['expires'])) {
-            $exp = new DrupalDateTime('now', $timezone);
-            $exp->setTimestamp($settings['expires']);
-            $expires = $exp;
-        }
+        $settings = $this->getConfiguration()['settings'];
 
         $form = parent::buildConfigurationForm($form, $form_state);
 
-        $php_url = Url::fromUserInput('https://www.php.net/manual/en/function.setcookie.php', ['attributes' => ['target' => '_blank']]);
+        $php_url = Url::fromUri('https://www.php.net/manual/en/function.setcookie.php', ['attributes' => ['target' => '_blank']]);
         $php_link = Link::fromTextAndUrl($this->t('PHP documentation'), $php_url);
         $form['cookie_info'] = [
             '#markup' => $this->t('For more information on the parameters for <em>setcookie</em>, please see the @documentation', ['@documentation' => $php_link->toString()])
@@ -81,23 +68,21 @@ class CookieWebformHandler extends WebformHandlerBase
             '#required' => TRUE,
         ];
 
+        $options = [300, 600, 900, 1800, 3600, 10800, 21600, 43200, 86400, 604800];
         $form['expires'] = [
-            '#type' => 'datetime',
-            '#title' => $this->t('Cookie expiration'),
-            '#description' => $this->t('The expiration date for the cookie. This can be a specific date in any valid date format.'),
-            '#date_date_format' => 'Y-m-d',
-            '#date_time_format' => 'H:i',
-            '#date_timezone' => $timezone = \Drupal::config('system.date')->get('timezone')['default'],
-            '#default_value' => $expires,
-            '#required' => TRUE,
+          '#type' => 'select',
+          '#title' => $this->t('Cookie expiration'),
+          '#description' => $this->t('The expiration time for the cookie.'),
+          '#default_value' => $settings['expires'] ?? 0,
+          '#required' => TRUE,
+          '#options' => [0 => t('Session')] + array_map([\Drupal::service('date.formatter'), 'formatInterval'], array_combine($options, $options)),
         ];
 
         $form['domain'] = [
             '#type' => 'textfield',
             '#title' => $this->t('Cookie domain'),
-            '#description' => $this->t('The (sub)domain that the cookie is available to. Default: %site', ['%site' => \Drupal::request()->getHost() ]),
-            '#default_value' => empty($settings['domain']) ? \Drupal::request()->getHost() : $settings['domain'],
-            '#required' => TRUE,
+            '#description' => $this->t('The (sub)domain that the cookie is available to. Leave empty to use default: %site', ['%site' => \Drupal::request()->getHost() ]),
+            '#default_value' => $settings['domain'],
         ];
 
         $form['secure'] = [
@@ -105,7 +90,6 @@ class CookieWebformHandler extends WebformHandlerBase
             '#title' => $this->t('Secure'),
             '#description' => $this->t('When checked, indicates that the cookie should only be transmitted over a secure HTTPS connection from the client.'),
             '#default_value' => $settings['secure'],
-            '#required' => TRUE,
         ];
 
         $form['http_only'] = [
@@ -113,7 +97,6 @@ class CookieWebformHandler extends WebformHandlerBase
             '#title' => $this->t('HTTP only'),
             '#description' => $this->t('When checked the cookie will be made accessible only through the HTTP protocol.'),
             '#default_value' => $settings['http_only'],
-            '#required' => TRUE,
         ];
 
         return $form;
@@ -121,8 +104,6 @@ class CookieWebformHandler extends WebformHandlerBase
 
     public function submitConfigurationForm(array &$form, FormStateInterface $form_state)
     {
-        $timestamp = $form_state->getValue('expires')->getTimestamp();
-        $form_state->setValue('expires', $timestamp);
         $this->applyFormStateToConfiguration($form_state);
     }
 
@@ -136,11 +117,13 @@ class CookieWebformHandler extends WebformHandlerBase
      */
     public function postSave(WebformSubmissionInterface $webform_submission, $update = TRUE)
     {
-        $config = $this->getConfiguration();
-        $name = trim($config['settings']['name']);
-        $value = rawurlencode($this->tokenManager->replace($config['settings']['value'], $webform_submission));
-        $expires = trim($config['settings']['expires']);
-        $domain = trim($config['settings']['domain']);
-        $result = setcookie($name, $value, $expires, '/', $domain);
+        $settings = $this->getConfiguration()['settings'];
+        $name = trim($settings['name']);
+        $value = rawurlencode($this->tokenManager->replace($settings['value'], $webform_submission));
+        $expires = $settings['expires'] > 0 ? \Drupal::time()->getRequestTime() + $settings['expires'] : 0;
+        $domain = trim($settings['domain']) ?: \Drupal::request()->getHost();
+        $secure = (bool) $settings['secure'];
+        $http_only = (bool) $settings['http_only'];
+        setcookie($name, $value, $expires, '/', $domain, $secure, $http_only);
     }
 }

--- a/templates/webform-handler-cookie-summary.html.twig
+++ b/templates/webform-handler-cookie-summary.html.twig
@@ -16,26 +16,46 @@
  *   - handler_id: The handler id.
  *   - label: The handler label.
  *   - description: The handler description.
+ * - name: The name of the cookie to be set.
+ * - value: The value of the cookie to be set.
+ * - expires: The expiration time for the cookie.
+ * - domain: The (sub)domain that the cookie is available to.
+ * - secure: Indicates that the cookie should only be transmitted over a secure HTTPS connection from the client.
+ * - http_only: When TRUE the cookie will be made accessible only through the HTTP protocol.
  *
  * @ingroup themeable
  */
 #}
+
 {% if settings.debug %}<b class="color-error">{{ 'Debugging is enabled'|t }}</b><br />{% endif %}
+
 <div>
-    <b>Cookie name:</b> {{ settings.name }}
+  {% trans %}
+    <b>Cookie name:</b> {{ name }}
+  {% endtrans %}
 </div>
 <div>
-    <b>Cookie value:</b> {{ settings.value }}
+  {% trans %}
+    <b>Cookie value:</b> {{ value }}
+  {% endtrans %}
 </div>
 <div>
-    <b>Cookie expires:</b> {{ settings.expires|format_date('short') }}
+  {% trans %}
+    <b>Cookie expiration:</b> {{ expires }}
+  {% endtrans %}
 </div>
 <div>
-    <b>Domain:</b> {{ settings.domain }}
+  {% trans %}
+    <b>Domain:</b> {{ domain }}
+  {% endtrans %}
 </div>
 <div>
-    <b>Secure:</b> {{ settings.secure ? 'Yes'|t : 'No'|t }}
+  {% trans %}
+    <b>Secure:</b> {{ secure }}
+  {% endtrans %}
 </div>
 <div>
-    <b>HTTP only:</b> {{ settings.http_only ? 'Yes'|t : 'No'|t }}
+  {% trans %}
+    <b>HTTP only:</b> {{ http_only }}
+  {% endtrans %}
 </div>

--- a/webform_cookie.module
+++ b/webform_cookie.module
@@ -29,7 +29,8 @@ function webform_cookie_help($route_name, RouteMatchInterface $route_match) {
 function webform_cookie_theme() {
   return [
     'webform_handler_cookie_summary' => [
-      'variables' => ['settings' => NULL, 'handler' => [] ],
+      'variables' => ['settings' => NULL, 'handler' => NULL ],
+      'file' => 'webform_cookie.theme.inc',
     ],
   ];
 }

--- a/webform_cookie.theme.inc
+++ b/webform_cookie.theme.inc
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @file
+ * Theme and preprocess functions for webform_cookie module.
+ */
+
+/**
+ * Implements hook_preporcess_webform_handler_cookie_summary().
+ */
+function webform_cookie_preprocess_webform_handler_cookie_summary(array &$variables) {
+  $settings = $variables['settings'];
+
+  $variables['name'] = trim($settings['name']);
+  $variables['value'] = $settings['value'];
+  $variables['expires'] = $settings['expires'] > 0 ? \Drupal::service('date.formatter')->formatInterval($settings['expires']) : t('Session');
+  $variables['domain'] = trim($settings['domain']) ?: \Drupal::request()->getHost();
+  $variables['secure'] = $settings['secure'] ? t('Yes') : t('No');
+  $variables['http_only'] = $settings['http_only'] ? t('Yes') : t('No');
+}


### PR DESCRIPTION
1. Url::fromUserInput() doesn't accept external URLs, replace it with Url::fromUri.
2. Absolute value of cookie expiration is not correct, better to use relative value in seconds; ability to expire along with session.
3. Ability to use current domain, if cookie domain setting is empty (in order to work correctly on all environments).
4. Ability to create insecure cookie as well as not http_only (make fields not required in configuration form).
5. Translatable strings fully translatable in webform_handler_cookie_summary theme.